### PR TITLE
Comms nuget package

### DIFF
--- a/Comms/Comms.fsproj
+++ b/Comms/Comms.fsproj
@@ -35,27 +35,51 @@
     <Compile Include="DocsController.fs" />
     <Compile Include="Logging.fs" />
     <Compile Include="Program.fs" />
-    <None Include="packages.config" />
     <Content Include="app.config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <EmbeddedResource Include="api.json" />
+    <Content Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="AWSSDK.Core">
-      <HintPath>..\packages\AWSSDK.Core.3.1.5.1\lib\net45\AWSSDK.Core.dll</HintPath>
+      <HintPath>..\packages\AWSSDK.Core.3.1.5.3\lib\net45\AWSSDK.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="AWSSDK.DynamoDBv2">
       <HintPath>..\packages\AWSSDK.DynamoDBv2.3.1.3.0\lib\net45\AWSSDK.DynamoDBv2.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Bristech.Srm.HttpConfig">
+      <HintPath>..\packages\Bristech.Srm.HttpConfig.0.1.2.0\lib\net45\Bristech.Srm.HttpConfig.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="FSharp.Core">
-      <HintPath>..\packages\FSharp.Core.3.1.2.5\lib\net40\FSharp.Core.dll</HintPath>
+      <HintPath>..\packages\FSharp.Core.4.0.0.1\lib\net40\FSharp.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.Owin">
+      <HintPath>..\packages\Microsoft.Owin.2.0.2\lib\net45\Microsoft.Owin.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Host.HttpListener">
+      <HintPath>..\packages\Microsoft.Owin.Host.HttpListener.2.0.2\lib\net45\Microsoft.Owin.Host.HttpListener.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Hosting">
+      <HintPath>..\packages\Microsoft.Owin.Hosting.2.0.2\lib\net45\Microsoft.Owin.Hosting.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="mscorlib" />
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Owin">
+      <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Serilog">
       <HintPath>..\packages\Serilog.1.5.14\lib\net45\Serilog.dll</HintPath>
       <Private>True</Private>
@@ -68,37 +92,31 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Data.Linq" />
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Formatting">
       <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Cors">
       <HintPath>..\packages\Microsoft.AspNet.Cors.5.2.3\lib\net45\System.Web.Cors.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.Http">
       <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
-    </Reference>
-    <Reference Include="Owin">
-      <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Owin">
-      <HintPath>..\packages\Microsoft.Owin.2.0.2\lib\net45\Microsoft.Owin.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.Http.Cors">
       <HintPath>..\packages\Microsoft.AspNet.WebApi.Cors.5.2.3\lib\net45\System.Web.Http.Cors.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.Http.Owin">
       <HintPath>..\packages\Microsoft.AspNet.WebApi.Owin.5.2.3\lib\net45\System.Web.Http.Owin.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Owin.Hosting">
-      <HintPath>..\packages\Microsoft.Owin.Hosting.2.0.2\lib\net45\Microsoft.Owin.Hosting.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Owin.Host.HttpListener">
-      <HintPath>..\packages\Microsoft.Owin.Host.HttpListener.2.0.2\lib\net45\Microsoft.Owin.Host.HttpListener.dll</HintPath>
+    <Reference Include="System.Web.Http.WebHost">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.WebHost.5.2.3\lib\net45\System.Web.Http.WebHost.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
 </Project>

--- a/Comms/Comms.fsproj
+++ b/Comms/Comms.fsproj
@@ -39,7 +39,7 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <EmbeddedResource Include="api.json" />
-    <Content Include="packages.config" />
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="AWSSDK.Core">

--- a/Comms/packages.config
+++ b/Comms/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AWSSDK.Core" version="3.1.5.3" targetFramework="net45" />
+  <package id="AWSSDK.Core" version="3.1.5.1" targetFramework="net45" />
   <package id="AWSSDK.DynamoDBv2" version="3.1.3.0" targetFramework="net45" />
   <package id="Bristech.Srm.HttpConfig" version="0.1.2.0" targetFramework="net45" />
   <package id="FSharp.Core" version="4.0.0.1" targetFramework="net45" />

--- a/Comms/packages.config
+++ b/Comms/packages.config
@@ -1,15 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Bristech.Srm.HttpConfig" version="0.1.2.0" targetFramework="net45" />
-  <package id="AWSSDK.Core" version="3.1.5.1" targetFramework="net45" />
+  <package id="AWSSDK.Core" version="3.1.5.3" targetFramework="net45" />
   <package id="AWSSDK.DynamoDBv2" version="3.1.3.0" targetFramework="net45" />
-  <package id="FSharp.Core" version="3.1.2.5" targetFramework="net45" />
+  <package id="Bristech.Srm.HttpConfig" version="0.1.2.0" targetFramework="net45" />
+  <package id="FSharp.Core" version="4.0.0.1" targetFramework="net45" />
   <package id="Microsoft.AspNet.Cors" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Cors" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Owin" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.OwinSelfHost" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.Owin" version="2.0.2" targetFramework="net45" />
   <package id="Microsoft.Owin.Host.HttpListener" version="2.0.2" targetFramework="net45" />
   <package id="Microsoft.Owin.Hosting" version="2.0.2" targetFramework="net45" />

--- a/Comms/packages.config
+++ b/Comms/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AWSSDK.Core" version="3.1.5.1" targetFramework="net45" />
+  <package id="AWSSDK.Core" version="3.1.5.3" targetFramework="net45" />
   <package id="AWSSDK.DynamoDBv2" version="3.1.3.0" targetFramework="net45" />
   <package id="Bristech.Srm.HttpConfig" version="0.1.2.0" targetFramework="net45" />
   <package id="FSharp.Core" version="4.0.0.1" targetFramework="net45" />


### PR DESCRIPTION
FSharp.Core updated to fix Bristech.Srm.HttpConfig package

In Visual Studio this time, so
Lost of the changes are ^M.  Sorry.
packages.config has moved from a "<None Include" to a "<Content Include".
AWSSDK.Core has updated itself to 3.1.5.3.
